### PR TITLE
Remove rscss

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,6 @@ A common config that detects possible errors and enforces "common stylistic conv
 found within a handful of CSS styleguides, including: The Idiomatic CSS Principles,
 Google's CSS Style Guide, Airbnb's Styleguide, and @mdo's Code Guide."
 
-- [stylelint-rscss](https://github.com/rstacruz/stylelint-rscss) – A config and
-plugin that enforces conventions from [rscss](http://rscss.io/) (Reasonable
-System for CSS Stylesheet Structure), "a set of simple ideas to guide your
-process of building maintainable CSS."
-
 - [stylelint-config-rational-order](https://www.npmjs.com/package/stylelint-config-rational-order) –
 Sorts related property declarations by grouping and ordering them as follows:
 
@@ -151,8 +146,3 @@ take care of that.
 
 We configure a number of options from the `stylelint-scss` plugin. Too many to
 describe here, but hopefully all sensible.
-
-#### `rscss/class-format`
-
-[Override rscss's buggy class format](https://github.com/rstacruz/stylelint-rscss/issues/9#issuecomment-357462211)
-to allow nested components, as encouraged by the rscss spec.

--- a/main.js
+++ b/main.js
@@ -3,7 +3,6 @@
 module.exports = {
     "extends": [
       "stylelint-config-standard",
-      "stylelint-rscss/config",
       "stylelint-config-rational-order"
     ],
     "plugins": [
@@ -35,9 +34,6 @@ module.exports = {
         ],
         "aditayvm/at-rule-no-children": true,
         "plugin/declaration-block-no-ignored-properties": true,
-        "rscss/class-format": [true, {
-            "element": "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$"
-        }],
         "at-rule-no-unknown": null,
         "scss/at-rule-no-unknown": true,
         "scss/at-else-closing-brace-newline-after": "always-last-in-chain",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "stylelint-config-standard": "^18.2.0",
     "stylelint-declaration-block-no-ignored-properties": "^1.1.0",
     "stylelint-order": "^0.8.1",
-    "stylelint-rscss": "^0.4.0",
     "stylelint-scss": "^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,10 +688,6 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flatten@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
-
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1555,7 +1551,7 @@ postcss-reporter@^5.0.0:
     log-symbols "^2.0.0"
     postcss "^6.0.8"
 
-postcss-resolve-nested-selector@0.1.1, postcss-resolve-nested-selector@^0.1.1:
+postcss-resolve-nested-selector@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
 
@@ -1577,14 +1573,6 @@ postcss-scss@^1.0.2:
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-1.0.5.tgz#40a10cfd03766accf0a3cf8e65a8af887b2bf6c4"
   dependencies:
     postcss "^6.0.21"
-
-postcss-selector-parser@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.1.tgz#fdbf696103b12b0a64060e5610507f410491f7c8"
-  dependencies:
-    flatten "^1.0.2"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
 
 postcss-selector-parser@^3.1.0:
   version "3.1.1"
@@ -2012,13 +2000,6 @@ stylelint-order@^0.8.0, stylelint-order@^0.8.1:
     lodash "^4.17.4"
     postcss "^6.0.14"
     postcss-sorting "^3.1.0"
-
-stylelint-rscss@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/stylelint-rscss/-/stylelint-rscss-0.4.0.tgz#ea77c478e1c703dbda878c00f53bbc002b2d07b7"
-  dependencies:
-    postcss-resolve-nested-selector "0.1.1"
-    postcss-selector-parser "2.2.1"
 
 stylelint-scss@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
The design team has decided to author all new CSS according to the [BEM methodology](http://getbem.com/). 

Accordingly, this PR removes `stylelint-rscss` so that we stop checking for rscss compliance. 

Future work (#4) will look into adding BEM support.