### PR TITLE
Remove scss/at-mixin-named-arguments rule

### DIFF
--- a/main.js
+++ b/main.js
@@ -47,7 +47,6 @@ module.exports = {
         "scss/at-if-closing-brace-space-after": "always-intermediate",
         "scss/at-import-no-partial-leading-underscore": true,
         "scss/at-mixin-argumentless-call-parentheses": "always",
-        "scss/at-mixin-named-arguments": "always",
         "scss/at-mixin-parentheses-space-before": "never",
         "scss/dollar-variable-colon-newline-after": "always-multi-line",
         "scss/dollar-variable-colon-space-after": "always-single-line",


### PR DESCRIPTION
It doesn't play nice with include-media, which uses a variable-length
argslist as its parameter(s).

Closes #10.
Closes azavea/facade#20.